### PR TITLE
Fixed userAvatar size

### DIFF
--- a/components/VacancyCard.vue
+++ b/components/VacancyCard.vue
@@ -86,6 +86,8 @@ export default {
   .serviceLogo img {
     height: 2rem;
     width: 2rem;
+    min-height: 2rem;
+    min-width: 2rem;
     margin-right: 1rem;
     object-fit: cover;
     border-radius: 50%;


### PR DESCRIPTION
Ajuste simples na imagem do avatar do usuário, na primeira vez que se entra na listagem das vagas, as imagens do avatar ficam "espremidas" e ao mudar de rotas também (Mobile / Front-end / Back-end ), ao atualizar a página os avatares ficam com a largura normal.

**Comportamento atual**

![Comportamento atual](https://i.imgur.com/BBBAmaX.png)

**Comportamento esperado / ajustado**

![Comportamento esperado / ajustado](https://i.imgur.com/xMxQSAx.png)

:rocket: